### PR TITLE
fix(messenger): pad zero-microsecond opt_start_time to dodge nats-py round-trip bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "serverish"
-version = "2.0.0"
+version = "2.0.1"
 description = "helpers for server alike projects"
 authors = ["Mikołaj Kałuszyński", "MMME team"]
 readme = "README.md"

--- a/serverish/messenger/msg_reader.py
+++ b/serverish/messenger/msg_reader.py
@@ -678,7 +678,18 @@ class MsgReader(MsgDriver):
                                 f"=>{self.opt_start_time.astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
                                 f" , use e.g. `datetime.now(tz=timezone.utc)`")
 
-                cfg['opt_start_time'] = self.opt_start_time.astimezone(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+                ts_utc = self.opt_start_time.astimezone(tz=timezone.utc)
+                # Workaround for nats-py round-trip bug: ``Base._to_utc_iso``
+                # strips ``.000000`` on whole-second values, but
+                # ``Base._parse_utc_iso`` unconditionally splits on '.', so the
+                # consumer-info echo for a zero-microsecond ``opt_start_time``
+                # raises ``ValueError: not enough values to unpack``. Bump
+                # microseconds to 1 so the server always echoes a fractional
+                # part. Harmless: 1 µs is well below JetStream's storage
+                # resolution and the start-time semantics.
+                if ts_utc.microsecond == 0:
+                    ts_utc = ts_utc.replace(microsecond=1)
+                cfg['opt_start_time'] = ts_utc.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
         # Create the pull consumer configuration
         consumer_conf = ConsumerConfig(**cfg)

--- a/tests/test_delivery_policies.py
+++ b/tests/test_delivery_policies.py
@@ -6,6 +6,7 @@ import uuid
 import pytest
 
 from serverish.messenger import Messenger, get_publisher, get_reader
+from serverish.messenger.msg_reader import MsgReader
 
 
 @pytest.mark.nats
@@ -267,3 +268,45 @@ async def test_reader_sequence_tracking(messenger, unique_subject):
     assert [msg['index'] for msg in collected_second] == [4, 0, 1, 2]
     assert collected_second[0]['batch'] == 1  # Last message from first batch
     assert all(msg['batch'] == 2 for msg in collected_second[1:])  # New messages
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for zero-microsecond opt_start_time workaround (no NATS needed)
+# ---------------------------------------------------------------------------
+
+async def test_consumer_cfg_zero_microsecond_is_bumped_to_one():
+    """opt_start_time with microsecond==0 must be bumped to 1 µs.
+
+    nats-py's Base._to_utc_iso strips '.000000' on whole-second values, but
+    Base._parse_utc_iso unconditionally splits on '.' — so an echo of the
+    stored timestamp raises ValueError.  The workaround pads zero-microsecond
+    timestamps to 1 µs before sending to the server.
+    """
+    m = Messenger()
+    t0 = datetime.datetime(2026, 4, 25, 16, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    assert t0.microsecond == 0
+
+    rdr = MsgReader('test.unit', parent=m, deliver_policy='by_start_time',
+                    opt_start_time=t0)
+    cfg = await rdr._create_consumer_cfg()
+
+    # The formatted string must contain a fractional part (not end in ':00Z')
+    assert cfg.opt_start_time is not None
+    assert '.' in cfg.opt_start_time, (
+        f"opt_start_time '{cfg.opt_start_time}' has no fractional part; "
+        "nats-py _parse_utc_iso would raise ValueError"
+    )
+    assert not cfg.opt_start_time.endswith('.000000Z'), (
+        "opt_start_time still has zero microseconds — nats-py round-trip will fail"
+    )
+
+
+async def test_consumer_cfg_nonzero_microsecond_is_unchanged():
+    """opt_start_time with microsecond != 0 must not be modified."""
+    m = Messenger()
+    t = datetime.datetime(2026, 4, 25, 16, 0, 0, 123456, tzinfo=datetime.timezone.utc)
+    rdr = MsgReader('test.unit', parent=m, deliver_policy='by_start_time',
+                    opt_start_time=t)
+    cfg = await rdr._create_consumer_cfg()
+
+    assert cfg.opt_start_time == '2026-04-25T16:00:00.123456Z'


### PR DESCRIPTION
## Summary

JetStream consumer creation with `deliver_policy='by_start_time'` fails when `opt_start_time` has `microsecond == 0`:

```
ValueError: not enough values to unpack (expected 2, got 1)
  at nats/js/api.py:117 in Base._parse_utc_iso → s.split(".", 1)
```

## Root cause (in nats-py, not us)

`nats-py`'s `nats/js/api.py` has a self-inconsistent round-trip:
- **`Base._to_utc_iso`** strips `.000000` for whole-second values (line ~110): `…replace(".000000", "")`
- **`Base._parse_utc_iso`** unconditionally does `s.split(".", 1)` (line 117), so it crashes on the same dot-less output it produces.

When we send `opt_start_time = 2026-04-25T16:00:00.000000Z`, NATS stores it, then `consumer_info` echoes `2026-04-25T16:00:00Z` back, which `_parse_utc_iso` then chokes on.

## Why this hits real callers

The natural way to construct a "noon" / "midnight" / "yesterday-local-noon" start-time is `datetime.now(tz=utc).replace(hour=…, minute=0, second=0, microsecond=0)` — which trips this every time. Calls using raw `datetime.now(...)` usually slip by because microseconds happen to be non-zero.

## Reproducer

```python
import asyncio, datetime
from serverish.messenger import Messenger, get_reader

async def main():
    m = Messenger(); await m.open(host='nats.lan', port=4222)
    night = datetime.datetime.now(datetime.timezone.utc).replace(
        hour=16, minute=0, second=0, microsecond=0)
    rdr = get_reader('foo.bar', deliver_policy='by_start_time',
                     opt_start_time=night, error_behavior='RAISE')
    await rdr.open()  # ValueError
```

Setting `microsecond=1` instead → `OPEN OK ✓`.

## Fix

`MsgReader._create_consumer_cfg` bumps a zero-microsecond `opt_start_time` to 1 µs before formatting, so the server always echoes a fractional part and `nats-py`'s parser stays happy. Negligible drift (1 µs) vs. losing the entire `by_start_time` API.

A proper upstream fix in nats-py would be ~3 lines in `_parse_utc_iso`:

```python
if "." in s:
    date_part, frac_tz = s.split(".", 1)
    frac, tz = frac_tz.split("+", 1)
    s = f"{date_part}.{frac[:6]}+{tz}"
```

Worth filing there as well; this PR is the immediate workaround so serverish 2.0.x users on current `nats-py` aren't blocked.

## Test plan

- [ ] Reproduce against any JetStream subject with `microsecond=0` start — confirms the failure pre-fix.
- [ ] Re-run with the patched build — `await rdr.open()` returns cleanly.
- [ ] No regression for non-zero microsecond values (already works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)