### PR TITLE
Stop leaking JetStream consumers on reopen; tighten reconnect detection (2.0.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "serverish"
-version = "2.0.2"
+version = "2.0.3"
 description = "helpers for server alike projects"
 authors = ["Mikołaj Kałuszyński", "MMME team"]
 readme = "README.md"

--- a/serverish/messenger/msg_reader.py
+++ b/serverish/messenger/msg_reader.py
@@ -292,10 +292,13 @@ class MsgReader(MsgDriver):
                             log.debug(self.fmt(f"No messages available, finishing due to nowait"))
                             raise self.EndIterationException('nowait')
 
-                        # Non-nowait mode: wait for NEW messages to arrive
-                        # Break into shorter intervals to allow health checks and reconnection handling
-                        blocking_interval = 10.0  # Check every 10 seconds
-                        max_wait_cycles = 10  # Total wait: 10 * 10s = 100s
+                        # Non-nowait mode: wait for NEW messages to arrive.
+                        # Break into shorter intervals so the reconnect-needed
+                        # check at the top of the loop runs often enough that
+                        # low-rate subjects don't sit on a stale subscription
+                        # for tens of seconds after a NATS reconnect.
+                        blocking_interval = 2.0
+                        max_wait_cycles = 50  # Total wait: 50 * 2s = 100s (unchanged)
 
                         for cycle in range(max_wait_cycles):
                             # Check for reconnection before each wait cycle
@@ -621,12 +624,28 @@ class MsgReader(MsgDriver):
         max_retries = 3
         for attempt in range(max_retries):
             try:
-                # Clean up existing subscription
+                # Clean up existing subscription. `unsubscribe()` only detaches the
+                # local handle; the JetStream consumer must be deleted explicitly
+                # or it leaks server-side across every reconnect (one orphan per
+                # reopen, accumulating until the stream's consumer cap or the
+                # process restarts).
                 if self.pull_subscription is not None:
+                    try:
+                        ci = await self.pull_subscription.consumer_info()
+                    except Exception as e:
+                        log.debug(f"Error fetching consumer_info during reopen attempt {attempt + 1}: {e}")
+                        ci = None
                     try:
                         await self.pull_subscription.unsubscribe()
                     except Exception as e:
                         log.debug(f"Error unsubscribing during reopen attempt {attempt + 1}: {e}")
+                    if ci is not None:
+                        try:
+                            await self.connection.js.delete_consumer(stream=ci.stream_name, consumer=ci.name)
+                        except nats.js.errors.NotFoundError:
+                            pass  # already gone, nothing to delete
+                        except Exception as e:
+                            log.debug(f"Error deleting old consumer during reopen attempt {attempt + 1}: {e}")
                 
                 # Create new consumer configuration
                 consumer_conf = await self._create_consumer_cfg()


### PR DESCRIPTION
## Bug

`MsgReader._reopen()` calls `pull_subscription.unsubscribe()` on the old subscription, which detaches the **local** handle but does **not** delete the server-side JetStream consumer. Each NATS reconnect therefore leaves an orphan consumer on the stream; one orphan per reopen, accumulating indefinitely until the process restarts (or the stream's consumer cap is hit).

Symptom in the field: monotonically growing \`nats consumer ls <stream>\` output, with consumer creation timestamps lining up with NATS reconnect events.

The teardown sequence in \`_close_pull_subscription()\` already shows the correct pattern: \`consumer_info() → unsubscribe() → delete_consumer()\`. \`_reopen()\` was just missing the \`delete_consumer()\` step.

## Fix

Two small changes in \`serverish/messenger/msg_reader.py\`:

1. **`_reopen()` now deletes the old consumer** (mirrors `_close_pull_subscription` teardown order). Capture \`consumer_info()\` before unsubscribing so we still know the consumer name; unsubscribe; then \`delete_consumer()\`. Failures at any step are logged and ignored — the new subscription is created regardless, matching the previous resilience.

2. **Tighten the reconnect-detection window** in the non-nowait wait loop. The outer loop only checks \`_reconnect_needed\` between fetch cycles, so a low-rate subject can sit on a dead pull subscription for up to one full cycle after a NATS reconnect (silent callbacks until detection). Reduce \`blocking_interval\` from 10s to 2s; bump \`max_wait_cycles\` from 10 to 50 so the total 100s wait window is unchanged.

## Compat

- Pull-consumer behaviour is unchanged for all callers; only the orphan-accumulation side-effect goes away.
- The 2s/50-cycle change keeps total wait identical (100s). High-rate subjects are unaffected (they fetch faster than 2s anyway). Low-rate subjects observe up to ~8s faster recovery after reconnect.

## Test plan

- [ ] Run a long-lived subscriber, kill+restart NATS several times, then \`nats consumer ls <stream>\`. With 2.0.2, count grows by N reconnects; with 2.0.3, count stays flat.
- [ ] Confirm a low-rate subscriber (≪1 msg/min) starts receiving messages within a few seconds of NATS reconnect, not tens of seconds later.